### PR TITLE
Improve example in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,12 @@ See [godoc.org][0] for usage instruction.
 Example:
 
 ```go
-client, e := omise.NewClient(OMISE_PUBKEY, OMISE_KEY)
+const (
+  OMISE_PUBLIC_KEY = "pkey_test_1234"
+  OMISE_SECRET_KEY = "skey_test_1234"
+)
+
+client, e := omise.NewClient(OMISE_PUBLIC_KEY, OMISE_SECRET_KEY)
 if e != nil {
   panic(e)
 }


### PR DESCRIPTION
This pr improve for

- Change OMISE_KEY to OMISE_SECRET_KEY
- Change OMISE_PUBKEY to OMISE_PUBLIC_KEY
- Move OMISE_PUBLIC_KEY and OMISE_SECRET_KEY to const and set
  sample key for easy to find in Omise web.