### PR TITLE
All remaining operations of Schedule API

### DIFF
--- a/operations/customer.go
+++ b/operations/customer.go
@@ -1,6 +1,8 @@
 package operations
 
 import (
+	"encoding/json"
+
 	"github.com/omise/omise-go/internal"
 )
 
@@ -125,5 +127,41 @@ func (req *DestroyCustomer) Op() *internal.Op {
 		Endpoint: internal.API,
 		Method:   "DELETE",
 		Path:     "/customers/" + req.CustomerID,
+	}
+}
+
+// ListCustomerChargeSchedules represent list customer schedule schedules API payload
+//
+// Example:
+//
+//      var schds omise.ScheduleList
+//	list := ListCustomerChargeSchedules{
+//		CustomerID: "cust_123"
+//		List: List{
+//			Limit: 100,
+//			From: time.Now().Add(-1 * time.Hour),
+//		},
+//	}
+//	if e := client.Do(&schds, &list); e != nil {
+//		panic(e)
+//	}
+//
+//	fmt.Println("# of schedules made in the last hour:", len(schds.Data))
+//
+type ListCustomerChargeSchedules struct {
+	CustomerID string
+	List
+}
+
+func (req *ListCustomerChargeSchedules) MarshalJSON() ([]byte, error) {
+	return json.Marshal(req.List)
+}
+
+func (req *ListCustomerChargeSchedules) Op() *internal.Op {
+	return &internal.Op{
+		Endpoint:    internal.API,
+		Method:      "GET",
+		Path:        "/customers/" + req.CustomerID + "/schedules",
+		ContentType: "application/json",
 	}
 }

--- a/operations/customer_test.go
+++ b/operations/customer_test.go
@@ -114,7 +114,7 @@ func TestCustomer_Network(t *testing.T) {
 	r.True(t, del.Deleted)
 }
 
-func TestListCustomerChargeSchedule(t *testing.T) {
+func TestListCustomerChargeSchedules(t *testing.T) {
 	client := testutil.NewFixedClient(t)
 	var schds omise.ScheduleList
 	client.MustDo(&schds, &ListCustomerChargeSchedules{
@@ -128,7 +128,7 @@ func TestListCustomerChargeSchedule(t *testing.T) {
 	r.Nil(t, schds.Data[0].Transfer)
 }
 
-func TestListCustomerChargeSchedule_Network(t *testing.T) {
+func TestListCustomerChargeSchedules_Network(t *testing.T) {
 	testutil.Require(t, "network")
 	client := testutil.NewTestClient(t)
 	var schds omise.ScheduleList

--- a/operations/customer_test.go
+++ b/operations/customer_test.go
@@ -113,3 +113,35 @@ func TestCustomer_Network(t *testing.T) {
 	r.Equal(t, jill.Live, del.Live)
 	r.True(t, del.Deleted)
 }
+
+func TestListCustomerChargeSchedule(t *testing.T) {
+	client := testutil.NewFixedClient(t)
+	var schds omise.ScheduleList
+	client.MustDo(&schds, &ListCustomerChargeSchedules{
+		CustomerID: "cust_test_4yq6txdpfadhbaqnwp3",
+	})
+
+	r.Len(t, schds.Data, 1)
+
+	r.Equal(t, "schd_57zhl296uxc7yiun6xa", schds.Data[0].ID)
+	r.NotNil(t, schds.Data[0].Charge)
+	r.Nil(t, schds.Data[0].Transfer)
+}
+
+func TestListCustomerChargeSchedule_Network(t *testing.T) {
+	testutil.Require(t, "network")
+	client := testutil.NewTestClient(t)
+	var schds omise.ScheduleList
+	list := ListCustomerChargeSchedules{
+		CustomerID: "cust_1234",
+		List: List{
+			Limit: 100,
+			From:  time.Date(2017, 5, 16, 0, 0, 0, 0, time.Local),
+		},
+	}
+
+	client.MustDo(&schds, &list)
+
+	t.Logf("Schedules Len: %d\n", len(schds.Data))
+	t.Logf("%#v\n", schds)
+}

--- a/operations/occurrence.go
+++ b/operations/occurrence.go
@@ -1,0 +1,26 @@
+package operations
+
+import "github.com/omise/omise-go/internal"
+
+// RetrieveOccurrence represent retrieve occurrence API payload
+//
+// Example:
+//
+//	var occurrence omise.Occurrence
+//	if e := client.Do(&occurrence, &RetrieveOccurrence{OccurrenceID: "occu_57z9hj228pusa652nk1"}); e != nil {
+//		panic(e)
+//	}
+//
+//	fmt.Printf("occurrence #occu_57z9hj228pusa652nk1: %#v\n", occurrence)
+//
+type RetrieveOccurrence struct {
+	OccurrenceID string `query:"-"`
+}
+
+func (req *RetrieveOccurrence) Op() *internal.Op {
+	return &internal.Op{
+		Endpoint: internal.API,
+		Method:   "GET",
+		Path:     "/occurrences/" + req.OccurrenceID,
+	}
+}

--- a/operations/occurrence_test.go
+++ b/operations/occurrence_test.go
@@ -1,0 +1,30 @@
+package operations
+
+import (
+	"testing"
+
+	omise "github.com/omise/omise-go"
+	"github.com/omise/omise-go/internal/testutil"
+	r "github.com/stretchr/testify/require"
+)
+
+func TestRetrieveOccurrence(t *testing.T) {
+	OccurrenceID := "occu_57z9hj228pusa652nk1"
+
+	client := testutil.NewFixedClient(t)
+	var occurrence omise.Occurrence
+	client.MustDo(&occurrence, &RetrieveOccurrence{OccurrenceID: OccurrenceID})
+	r.Equal(t, OccurrenceID, occurrence.ID)
+}
+
+func TestRetrieveOccurrence_Network(t *testing.T) {
+	// OccurrenceID must have this occurrence in test server
+	OccurrenceID := "occu_57z9hj228pusa652nk1"
+
+	testutil.Require(t, "network")
+	client := testutil.NewTestClient(t)
+	var occurrence omise.Occurrence
+	client.MustDo(&occurrence, &RetrieveOccurrence{OccurrenceID: OccurrenceID})
+
+	t.Logf("%#v\n", occurrence)
+}

--- a/operations/recipient.go
+++ b/operations/recipient.go
@@ -1,6 +1,8 @@
 package operations
 
 import (
+	"encoding/json"
+
 	"github.com/omise/omise-go"
 	"github.com/omise/omise-go/internal"
 )
@@ -135,5 +137,41 @@ func (req *DestroyRecipient) Op() *internal.Op {
 		Endpoint: internal.API,
 		Method:   "DELETE",
 		Path:     "/recipients/" + req.RecipientID,
+	}
+}
+
+// ListRecipientTransferSchedules represent list recipient transfer schedules API payload
+//
+// Example:
+//
+//      var schds omise.ScheduleList
+//	list := ListRecipientTransferSchedules{
+//		RecipientID: "reci_123"
+//		List: List{
+//			Limit: 100,
+//			From: time.Now().Add(-1 * time.Hour),
+//		},
+//	}
+//	if e := client.Do(&schds, &list); e != nil {
+//		panic(e)
+//	}
+//
+//	fmt.Println("# of schedules made in the last hour:", len(schds.Data))
+//
+type ListRecipientTransferSchedules struct {
+	RecipientID string
+	List
+}
+
+func (req *ListRecipientTransferSchedules) MarshalJSON() ([]byte, error) {
+	return json.Marshal(req.List)
+}
+
+func (req *ListRecipientTransferSchedules) Op() *internal.Op {
+	return &internal.Op{
+		Endpoint:    internal.API,
+		Method:      "GET",
+		Path:        "/recipients/" + req.RecipientID + "/schedules",
+		ContentType: "application/json",
 	}
 }

--- a/operations/recipient_test.go
+++ b/operations/recipient_test.go
@@ -108,3 +108,35 @@ func TestRecipient_Network(t *testing.T) {
 	r.Equal(t, jones.Live, del.Live)
 	r.True(t, del.Deleted)
 }
+
+func TestListRecipientTransferSchedules(t *testing.T) {
+	client := testutil.NewFixedClient(t)
+	var schds omise.ScheduleList
+	client.MustDo(&schds, &ListRecipientTransferSchedules{
+		RecipientID: "recp_test_50894vc13y8z4v51iuc",
+	})
+
+	r.Len(t, schds.Data, 1)
+
+	r.Equal(t, "schd_57zhl296uxc7yiun6xx", schds.Data[0].ID)
+	r.NotNil(t, schds.Data[0].Transfer)
+	r.Nil(t, schds.Data[0].Charge)
+}
+
+func TestListRecipientTransferSchedules_Network(t *testing.T) {
+	testutil.Require(t, "network")
+	client := testutil.NewTestClient(t)
+	var schds omise.ScheduleList
+	list := ListRecipientTransferSchedules{
+		RecipientID: "reci_1234",
+		List: List{
+			Limit: 100,
+			From:  time.Date(2017, 5, 16, 0, 0, 0, 0, time.Local),
+		},
+	}
+
+	client.MustDo(&schds, &list)
+
+	t.Logf("Schedules Len: %d\n", len(schds.Data))
+	t.Logf("%#v\n", schds)
+}

--- a/operations/schedule.go
+++ b/operations/schedule.go
@@ -278,6 +278,42 @@ func (req *ListSchedules) Op() *internal.Op {
 	}
 }
 
+// ListScheduleOccurrences represent list schedule occurrences API payload
+//
+// Example:
+//
+//      var occurrences omise.OccurrenceList
+//	list := ListOccurrenceSchedules{
+//		ScheduleID: "schd_57z9hj228pusa652nk1",
+//		List: List{
+//			Limit: 100,
+//			From: time.Now().Add(-1 * time.Hour),
+//		},
+//	}
+//	if e := client.Do(&occurrences, &list); e != nil {
+//		panic(e)
+//	}
+//
+//	fmt.Println("occurrences made in the last hour:", len(occurrences.Data))
+//
+type ListScheduleOccurrences struct {
+	ScheduleID string `query:"-"`
+	List
+}
+
+func (req *ListScheduleOccurrences) MarshalJSON() ([]byte, error) {
+	return json.Marshal(req.List)
+}
+
+func (req *ListScheduleOccurrences) Op() *internal.Op {
+	return &internal.Op{
+		Endpoint:    internal.API,
+		Method:      "GET",
+		Path:        "/schedules/" + req.ScheduleID + "/occurrences",
+		ContentType: "application/json",
+	}
+}
+
 // ListChargeSchedules represent list charge schedules API payload
 //
 // Example:

--- a/operations/schedule.go
+++ b/operations/schedule.go
@@ -14,7 +14,8 @@ import (
 //
 // Example:
 //
-//	schd, create := &omise.Schedule{}, &operations.CreateChargeSchedule{
+//	var schd omise.Schedule
+//	create := operations.CreateChargeSchedule{
 //              Every:  3,
 //              Period: schedule.PeriodWeek,
 //              Weekdays: []schedule.Weekday{
@@ -26,7 +27,7 @@ import (
 //              Customer:  "customer_id",
 //              Amount:    100000,
 //	}
-//	if e := client.Do(schd, create); e != nil {
+//	if e := client.Do(&schd, &create); e != nil {
 //		panic(e)
 //	}
 //
@@ -133,7 +134,8 @@ func (req *CreateChargeSchedule) Op() *internal.Op {
 //
 // Example:
 //
-//	schd, create := &omise.Schedule{}, &operations.CreateTransferSchedule{
+//	var schd omise.Schedule
+//	create = operations.CreateTransferSchedule{
 //              Every:  3,
 //              Period: schedule.PeriodWeek,
 //              Weekdays: []schedule.Weekday{
@@ -145,7 +147,7 @@ func (req *CreateChargeSchedule) Op() *internal.Op {
 //              Recipient:  "recipient_id",
 //              Amount:    100000,
 //	}
-//	if e := client.Do(schd, create); e != nil {
+//	if e := client.Do(&schd, &create); e != nil {
 //		panic(e)
 //	}
 //
@@ -246,13 +248,14 @@ func (req *CreateTransferSchedule) Op() *internal.Op {
 //
 // Example:
 //
-//	schds, list := &omise.ScheduleList{}, &ListSchedules{
-//		List{
+//      var schds omise.ScheduleList
+//	list := ListSchedules{
+//		List: List{
 //			Limit: 100,
 //			From: time.Now().Add(-1 * time.Hour),
 //		},
 //	}
-//	if e := client.Do(schds, list); e != nil {
+//	if e := client.Do(&schds, &list); e != nil {
 //		panic(e)
 //	}
 //
@@ -275,12 +278,46 @@ func (req *ListSchedules) Op() *internal.Op {
 	}
 }
 
-// RetrieveSchedule
+// ListChargeSchedules represent list charge schedules API payload
 //
 // Example:
 //
-//	schd := &omise.Schedule{ID: "schd_57z9hj228pusa652nk1"}
-//	if e := client.Do(schd, &RetrieveSchedule{schd.ID}); e != nil {
+//      var schds omise.ScheduleList
+//	list = ListChargeSchedules{
+//		List: List{
+//			Limit: 100,
+//			From: time.Now().Add(-1 * time.Hour),
+//		},
+//	}
+//	if e := client.Do(&schds, &list); e != nil {
+//		panic(e)
+//	}
+//
+//	fmt.Println("# of charge schedules made in the last hour:", len(schds.Data))
+//
+type ListChargeSchedules struct {
+	List
+}
+
+func (req *ListChargeSchedules) MarshalJSON() ([]byte, error) {
+	return json.Marshal(req.List)
+}
+
+func (req *ListChargeSchedules) Op() *internal.Op {
+	return &internal.Op{
+		Endpoint:    internal.API,
+		Method:      "GET",
+		Path:        "/charges/schedules",
+		ContentType: "application/json",
+	}
+}
+
+// RetrieveSchedule represent retrieve schedule API payload
+//
+// Example:
+//
+//	var schd omise.Schedule
+//	if e := client.Do(&schd, &RetrieveSchedule{ScheduleID: "schd_57z9hj228pusa652nk1"}); e != nil {
 //		panic(e)
 //	}
 //
@@ -298,14 +335,15 @@ func (req *RetrieveSchedule) Op() *internal.Op {
 	}
 }
 
-// Example:
+// DestroySchedule represent destroy schedule API payload
 //
-//	del, destroy := &omise.Schedule{}, &DestroySchedule{"recp-123"}
-//	if e := client.Do(del, destroy); e != nil {
+// Example:
+//      var deletedSchd omise.Schedule
+//	if e := client.Do(&deletedSchd, &DestroySchedule{ScheduleID: "schd_57z9hj228pusa652nk1"}); e != nil {
 //		panic(e)
 //	}
 //
-//	fmt.Println("destroyed recipient:", del.ID)
+//	fmt.Println("destroyed schedule:", deletedSchd.ID)
 //
 type DestroySchedule struct {
 	ScheduleID string `query:"-"`

--- a/operations/schedule.go
+++ b/operations/schedule.go
@@ -312,6 +312,40 @@ func (req *ListChargeSchedules) Op() *internal.Op {
 	}
 }
 
+// ListTransferSchedules represent list transfer schedules API payload
+//
+// Example:
+//
+//      var schds omise.ScheduleList
+//	list = ListTransferSchedules{
+//		List: List{
+//			Limit: 100,
+//			From: time.Now().Add(-1 * time.Hour),
+//		},
+//	}
+//	if e := client.Do(&schds, &list); e != nil {
+//		panic(e)
+//	}
+//
+//	fmt.Println("# of transfer schedules made in the last hour:", len(schds.Data))
+//
+type ListTransferSchedules struct {
+	List
+}
+
+func (req *ListTransferSchedules) MarshalJSON() ([]byte, error) {
+	return json.Marshal(req.List)
+}
+
+func (req *ListTransferSchedules) Op() *internal.Op {
+	return &internal.Op{
+		Endpoint:    internal.API,
+		Method:      "GET",
+		Path:        "/transfers/schedules",
+		ContentType: "application/json",
+	}
+}
+
 // RetrieveSchedule represent retrieve schedule API payload
 //
 // Example:

--- a/operations/schedule_test.go
+++ b/operations/schedule_test.go
@@ -198,8 +198,8 @@ func TestCreateSchedule(t *testing.T) {
 
 func TestListSchedule(t *testing.T) {
 	client := testutil.NewFixedClient(t)
-	schds := &omise.ScheduleList{}
-	client.MustDo(schds, &ListSchedules{})
+	var schds omise.ScheduleList
+	client.MustDo(&schds, &ListSchedules{})
 
 	r.Len(t, schds.Data, 2)
 
@@ -215,13 +215,44 @@ func TestListSchedule(t *testing.T) {
 func TestListSchedules_Network(t *testing.T) {
 	testutil.Require(t, "network")
 	client := testutil.NewTestClient(t)
-	schds, list := &omise.ScheduleList{}, &ListSchedules{
-		List{
+	var schds omise.ScheduleList
+	list := ListSchedules{
+		List: List{
 			Limit: 100,
 			From:  time.Date(2017, 5, 16, 0, 0, 0, 0, time.Local),
 		},
 	}
-	client.MustDo(schds, list)
+
+	client.MustDo(&schds, &list)
+
+	t.Logf("Schedules Len: %d\n", len(schds.Data))
+	t.Logf("%#v\n", schds)
+}
+
+func TestListChargeSchedules(t *testing.T) {
+	var schds omise.ScheduleList
+	client := testutil.NewFixedClient(t)
+	client.MustDo(&schds, &ListChargeSchedules{})
+
+	r.Len(t, schds.Data, 1)
+
+	r.Equal(t, "schd_57zhl296uxc7yiun6xa", schds.Data[0].ID)
+	r.NotNil(t, schds.Data[0].Charge)
+	r.Nil(t, schds.Data[0].Transfer)
+}
+
+func TestListChargeSchedules_Network(t *testing.T) {
+	testutil.Require(t, "network")
+	client := testutil.NewTestClient(t)
+	var schds omise.ScheduleList
+	list := ListChargeSchedules{
+		List: List{
+			Limit: 100,
+			From:  time.Date(2017, 5, 16, 0, 0, 0, 0, time.Local),
+		},
+	}
+
+	client.MustDo(&schds, &list)
 
 	t.Logf("Schedules Len: %d\n", len(schds.Data))
 	t.Logf("%#v\n", schds)
@@ -232,7 +263,7 @@ func TestRetrieveSchedule(t *testing.T) {
 
 	client := testutil.NewFixedClient(t)
 	schd := &omise.Schedule{}
-	client.MustDo(schd, &RetrieveSchedule{ScheduleID})
+	client.MustDo(schd, &RetrieveSchedule{ScheduleID: ScheduleID})
 	r.Equal(t, ScheduleID, schd.ID)
 	r.Nil(t, schd.Transfer)
 	r.Equal(t, 100000, schd.Charge.Amount)
@@ -242,7 +273,7 @@ func TestRetrieveSchedule(t *testing.T) {
 	ScheduleID = "schd_57z9hj228pusa652nk2"
 
 	schd = &omise.Schedule{}
-	client.MustDo(schd, &RetrieveSchedule{ScheduleID})
+	client.MustDo(schd, &RetrieveSchedule{ScheduleID: ScheduleID})
 	r.Equal(t, ScheduleID, schd.ID)
 	r.Nil(t, schd.Charge)
 	r.Equal(t, 100000, *schd.Transfer.Amount)
@@ -257,7 +288,7 @@ func TestRetrieveSchedule_Network(t *testing.T) {
 	testutil.Require(t, "network")
 	client := testutil.NewTestClient(t)
 	schd := &omise.Schedule{}
-	client.MustDo(schd, &RetrieveSchedule{ScheduleID})
+	client.MustDo(schd, &RetrieveSchedule{ScheduleID: ScheduleID})
 
 	t.Logf("%#v\n", schd)
 }
@@ -267,7 +298,7 @@ func TestDestroySchedule(t *testing.T) {
 
 	client := testutil.NewFixedClient(t)
 	schd := &omise.Schedule{}
-	client.MustDo(schd, &DestroySchedule{ScheduleID})
+	client.MustDo(schd, &DestroySchedule{ScheduleID: ScheduleID})
 	r.Equal(t, ScheduleID, schd.ID)
 	r.Nil(t, schd.Transfer)
 	r.Equal(t, 100000, schd.Charge.Amount)
@@ -277,7 +308,7 @@ func TestDestroySchedule(t *testing.T) {
 	ScheduleID = "schd_57z9hj228pusa652nk2"
 
 	schd = &omise.Schedule{}
-	client.MustDo(schd, &DestroySchedule{ScheduleID})
+	client.MustDo(schd, &DestroySchedule{ScheduleID: ScheduleID})
 	r.Equal(t, ScheduleID, schd.ID)
 	r.Nil(t, schd.Charge)
 	r.Equal(t, 100000, *schd.Transfer.Amount)
@@ -292,7 +323,7 @@ func TestDestroySchedule_Network(t *testing.T) {
 	testutil.Require(t, "network")
 	client := testutil.NewTestClient(t)
 	schd := &omise.Schedule{}
-	client.MustDo(schd, &DestroySchedule{ScheduleID})
+	client.MustDo(schd, &DestroySchedule{ScheduleID: ScheduleID})
 
 	t.Logf("%#v\n", schd)
 }

--- a/operations/schedule_test.go
+++ b/operations/schedule_test.go
@@ -258,6 +258,35 @@ func TestListChargeSchedules_Network(t *testing.T) {
 	t.Logf("%#v\n", schds)
 }
 
+func TestListTransferSchedules(t *testing.T) {
+	var schds omise.ScheduleList
+	client := testutil.NewFixedClient(t)
+	client.MustDo(&schds, &ListTransferSchedules{})
+
+	r.Len(t, schds.Data, 1)
+
+	r.Equal(t, "schd_57zhl296uxc7yiun6xx", schds.Data[0].ID)
+	r.NotNil(t, schds.Data[0].Transfer)
+	r.Nil(t, schds.Data[0].Charge)
+}
+
+func TestListTransferSchedules_Network(t *testing.T) {
+	testutil.Require(t, "network")
+	client := testutil.NewTestClient(t)
+	var schds omise.ScheduleList
+	list := ListTransferSchedules{
+		List: List{
+			Limit: 100,
+			From:  time.Date(2017, 5, 16, 0, 0, 0, 0, time.Local),
+		},
+	}
+
+	client.MustDo(&schds, &list)
+
+	t.Logf("Schedules Len: %d\n", len(schds.Data))
+	t.Logf("%#v\n", schds)
+}
+
 func TestRetrieveSchedule(t *testing.T) {
 	ScheduleID := "schd_57z9hj228pusa652nk1"
 

--- a/operations/schedule_test.go
+++ b/operations/schedule_test.go
@@ -287,6 +287,35 @@ func TestListTransferSchedules_Network(t *testing.T) {
 	t.Logf("%#v\n", schds)
 }
 
+func TestListScheduleOccurrences(t *testing.T) {
+	var occurrences omise.OccurrenceList
+	client := testutil.NewFixedClient(t)
+	client.MustDo(&occurrences, &ListScheduleOccurrences{ScheduleID: "schd_57z9hj228pusa652nk1"})
+
+	r.Len(t, occurrences.Data, 2)
+
+	r.Equal(t, "occu_588fwvt863w1w24et5u", occurrences.Data[0].ID)
+	r.Equal(t, "occu_588fwvt863w1w24et7u", occurrences.Data[1].ID)
+}
+
+func TestListScheduleOccurrences_Network(t *testing.T) {
+	testutil.Require(t, "network")
+	client := testutil.NewTestClient(t)
+	var occurrences omise.OccurrenceList
+	list := ListScheduleOccurrences{
+		ScheduleID: "schd_57z9hj228pusa652nk1",
+		List: List{
+			Limit: 100,
+			From:  time.Date(2017, 5, 16, 0, 0, 0, 0, time.Local),
+		},
+	}
+
+	client.MustDo(&occurrences, &list)
+
+	t.Logf("Occurrences Len: %d\n", len(occurrences.Data))
+	t.Logf("%#v\n", occurrences)
+}
+
 func TestRetrieveSchedule(t *testing.T) {
 	ScheduleID := "schd_57z9hj228pusa652nk1"
 

--- a/schedule/transfer_detail.go
+++ b/schedule/transfer_detail.go
@@ -2,8 +2,8 @@ package schedule
 
 // TransferDetail represents transfer detail for schedule object.
 type TransferDetail struct {
-	Recipient           string `json:"recipient"`
-	Amount              *int   `json:"amount"`
-	PercentageOfBalance *int   `json:"percentage_of_balance"`
-	Currency            string `json:"currency"`
+	Recipient           string   `json:"recipient"`
+	Amount              *int     `json:"amount"`
+	PercentageOfBalance *float64 `json:"percentage_of_balance"`
+	Currency            string   `json:"currency"`
 }

--- a/testdata/fixtures/api.omise.co/charges/schedules-get.json
+++ b/testdata/fixtures/api.omise.co/charges/schedules-get.json
@@ -1,0 +1,82 @@
+{
+  "object": "list",
+  "from": "1970-01-01T07:00:00+07:00",
+  "to": "2017-05-16T14:32:24+07:00",
+  "offset": 0,
+  "limit": 20,
+  "total": 1,
+  "order": "chronological",
+  "location": "/schedules",
+  "data": [
+    {
+      "object": "schedule",
+      "id": "schd_57zhl296uxc7yiun6xa",
+      "livemode": true,
+      "location": "/schedules/schd_57zhl296uxc7yiun6xa",
+      "status": "active",
+      "every": 3,
+      "period": "week",
+      "on": {
+        "weekdays": [
+          "monday",
+          "saturday"
+        ]
+      },
+      "in_words": "Every 3 week(s) on Monday and Saturday",
+      "start_date": "2017-05-16",
+      "end_date": "2018-05-15",
+      "charge": {
+        "amount": 100000,
+        "currency": "thb",
+        "customer": "cust_57z9e1nce0wvbbkvef1",
+        "card": null
+      },
+      "occurrences": {
+        "object": "list",
+        "from": "1970-01-01T07:00:00+07:00",
+        "to": "2017-05-16T14:32:25+07:00",
+        "offset": 0,
+        "limit": 20,
+        "total": 0,
+        "order": null,
+        "location": "/schedules/schd_57zhl296uxc7yiun6xa/occurrences",
+        "data": [
+
+        ]
+      },
+      "next_occurrences": [
+        "2017-05-20",
+        "2017-06-05",
+        "2017-06-10",
+        "2017-06-26",
+        "2017-07-01",
+        "2017-07-17",
+        "2017-07-22",
+        "2017-08-07",
+        "2017-08-12",
+        "2017-08-28",
+        "2017-09-02",
+        "2017-09-18",
+        "2017-09-23",
+        "2017-10-09",
+        "2017-10-14",
+        "2017-10-30",
+        "2017-11-04",
+        "2017-11-20",
+        "2017-11-25",
+        "2017-12-11",
+        "2017-12-16",
+        "2018-01-01",
+        "2018-01-06",
+        "2018-01-22",
+        "2018-01-27",
+        "2018-02-12",
+        "2018-02-17",
+        "2018-03-05",
+        "2018-03-10",
+        "2018-03-26"
+      ],
+      "created": "2017-05-16T07:23:11Z"
+    }
+  ]
+}

--- a/testdata/fixtures/api.omise.co/customers/cust_test_4yq6txdpfadhbaqnwp3/schedules-get.json
+++ b/testdata/fixtures/api.omise.co/customers/cust_test_4yq6txdpfadhbaqnwp3/schedules-get.json
@@ -1,0 +1,82 @@
+{
+  "object": "list",
+  "from": "1970-01-01T07:00:00+07:00",
+  "to": "2017-05-16T14:32:24+07:00",
+  "offset": 0,
+  "limit": 20,
+  "total": 1,
+  "order": "chronological",
+  "location": "/schedules",
+  "data": [
+    {
+      "object": "schedule",
+      "id": "schd_57zhl296uxc7yiun6xa",
+      "livemode": true,
+      "location": "/schedules/schd_57zhl296uxc7yiun6xa",
+      "status": "active",
+      "every": 3,
+      "period": "week",
+      "on": {
+        "weekdays": [
+          "monday",
+          "saturday"
+        ]
+      },
+      "in_words": "Every 3 week(s) on Monday and Saturday",
+      "start_date": "2017-05-16",
+      "end_date": "2018-05-15",
+      "charge": {
+        "amount": 100000,
+        "currency": "thb",
+        "customer": "cust_57z9e1nce0wvbbkvef1",
+        "card": null
+      },
+      "occurrences": {
+        "object": "list",
+        "from": "1970-01-01T07:00:00+07:00",
+        "to": "2017-05-16T14:32:25+07:00",
+        "offset": 0,
+        "limit": 20,
+        "total": 0,
+        "order": null,
+        "location": "/schedules/schd_57zhl296uxc7yiun6xa/occurrences",
+        "data": [
+
+        ]
+      },
+      "next_occurrences": [
+        "2017-05-20",
+        "2017-06-05",
+        "2017-06-10",
+        "2017-06-26",
+        "2017-07-01",
+        "2017-07-17",
+        "2017-07-22",
+        "2017-08-07",
+        "2017-08-12",
+        "2017-08-28",
+        "2017-09-02",
+        "2017-09-18",
+        "2017-09-23",
+        "2017-10-09",
+        "2017-10-14",
+        "2017-10-30",
+        "2017-11-04",
+        "2017-11-20",
+        "2017-11-25",
+        "2017-12-11",
+        "2017-12-16",
+        "2018-01-01",
+        "2018-01-06",
+        "2018-01-22",
+        "2018-01-27",
+        "2018-02-12",
+        "2018-02-17",
+        "2018-03-05",
+        "2018-03-10",
+        "2018-03-26"
+      ],
+      "created": "2017-05-16T07:23:11Z"
+    }
+  ]
+}

--- a/testdata/fixtures/api.omise.co/occurrences/occu_57z9hj228pusa652nk1-get.json
+++ b/testdata/fixtures/api.omise.co/occurrences/occu_57z9hj228pusa652nk1-get.json
@@ -1,0 +1,14 @@
+{
+  "object": "occurrence",
+  "id": "occu_57z9hj228pusa652nk1",
+  "livemode": false,
+  "location": "/occurrences/occu_57z9hj228pusa652nk1",
+  "schedule": "schd_test_588fwvto33q351wms2c",
+  "schedule_date": "2017-02-20",
+  "retry_date": "2017-02-22",
+  "processed_at": "2017-02-08T00:00:00Z",
+  "status": "failed",
+  "message": null,
+  "result": null,
+  "created": "2017-06-08T04:46:50Z"
+}

--- a/testdata/fixtures/api.omise.co/recipients/recp_test_50894vc13y8z4v51iuc/schedules-get.json
+++ b/testdata/fixtures/api.omise.co/recipients/recp_test_50894vc13y8z4v51iuc/schedules-get.json
@@ -1,0 +1,81 @@
+{
+  "object": "list",
+  "from": "1970-01-01T07:00:00+07:00",
+  "to": "2017-05-16T14:32:24+07:00",
+  "offset": 0,
+  "limit": 20,
+  "total": 1,
+  "order": "chronological",
+  "location": "/schedules",
+  "data": [
+    {
+      "object": "schedule",
+      "id": "schd_57zhl296uxc7yiun6xx",
+      "livemode": true,
+      "location": "/schedules/schd_57zhl296uxc7yiun6xx",
+      "status": "active",
+      "every": 3,
+      "period": "week",
+      "on": {
+        "weekdays": [
+          "monday",
+          "saturday"
+        ]
+      },
+      "in_words": "Every 3 week(s) on Monday and Saturday",
+      "start_date": "2017-05-16",
+      "end_date": "2018-05-15",
+      "transfer": {
+	      "recipient": "rcpt_57zhl296uxc7yiun6xx",
+        "amount": 100000,
+        "currency": "thb"
+      },
+      "occurrences": {
+        "object": "list",
+        "from": "1970-01-01T07:00:00+07:00",
+        "to": "2017-05-16T14:32:25+07:00",
+        "offset": 0,
+        "limit": 20,
+        "total": 0,
+        "order": null,
+        "location": "/schedules/schd_57zhl296uxc7yiun6xx/occurrences",
+        "data": [
+
+        ]
+      },
+      "next_occurrences": [
+        "2017-05-20",
+        "2017-06-05",
+        "2017-06-10",
+        "2017-06-26",
+        "2017-07-01",
+        "2017-07-17",
+        "2017-07-22",
+        "2017-08-07",
+        "2017-08-12",
+        "2017-08-28",
+        "2017-09-02",
+        "2017-09-18",
+        "2017-09-23",
+        "2017-10-09",
+        "2017-10-14",
+        "2017-10-30",
+        "2017-11-04",
+        "2017-11-20",
+        "2017-11-25",
+        "2017-12-11",
+        "2017-12-16",
+        "2018-01-01",
+        "2018-01-06",
+        "2018-01-22",
+        "2018-01-27",
+        "2018-02-12",
+        "2018-02-17",
+        "2018-03-05",
+        "2018-03-10",
+        "2018-03-26"
+      ],
+      "created": "2017-05-16T07:23:11Z"
+    }
+  ]
+}

--- a/testdata/fixtures/api.omise.co/schedules/schd_57z9hj228pusa652nk1/occurrences-get.json
+++ b/testdata/fixtures/api.omise.co/schedules/schd_57z9hj228pusa652nk1/occurrences-get.json
@@ -1,0 +1,39 @@
+{
+    "object": "list",
+    "from": "1970-01-01T07:00:00+07:00",
+    "to": "2017-05-16T00:35:01+07:00",
+    "offset": 0,
+    "limit": 20,
+    "total": 0,
+    "location": "/schedules/schd_57z9hj228pusa652nk1/occurrences",
+    "data": [
+      {
+        "object": "occurrence",
+        "id": "occu_588fwvt863w1w24et5u",
+        "livemode": false,
+        "location": "/occurrences/occu_588fwvt863w1w24et5u",
+        "schedule": "schd_test_588fwvto33q351wms2c",
+        "schedule_date": "2017-02-20",
+        "retry_date": "2017-02-22",
+        "processed_at": "2017-02-08T00:00:00Z",
+        "status": "failed",
+        "message": null,
+        "result": null,
+        "created": "2017-06-08T04:46:50Z"
+      },
+      {
+        "object": "occurrence",
+        "id": "occu_588fwvt863w1w24et7u",
+        "livemode": false,
+        "location": "/occurrences/occu_588fwvt863w1w24et7u",
+        "schedule": "schd_test_588fwvto33q351wms2c",
+        "schedule_date": "2017-02-20",
+        "retry_date": "2017-02-22",
+        "processed_at": "2017-02-08T00:00:00Z",
+        "status": "failed",
+        "message": null,
+        "result": null,
+        "created": "2017-06-08T04:46:50Z"
+      }
+    ]
+}

--- a/testdata/fixtures/api.omise.co/transfers/schedules-get.json
+++ b/testdata/fixtures/api.omise.co/transfers/schedules-get.json
@@ -4,80 +4,10 @@
   "to": "2017-05-16T14:32:24+07:00",
   "offset": 0,
   "limit": 20,
-  "total": 2,
+  "total": 1,
   "order": "chronological",
   "location": "/schedules",
   "data": [
-    {
-      "object": "schedule",
-      "id": "schd_57zhl296uxc7yiun6xa",
-      "livemode": true,
-      "location": "/schedules/schd_57zhl296uxc7yiun6xa",
-      "status": "active",
-      "every": 3,
-      "period": "week",
-      "on": {
-        "weekdays": [
-          "monday",
-          "saturday"
-        ]
-      },
-      "in_words": "Every 3 week(s) on Monday and Saturday",
-      "start_date": "2017-05-16",
-      "end_date": "2018-05-15",
-      "charge": {
-        "amount": 100000,
-        "currency": "thb",
-        "customer": "cust_57z9e1nce0wvbbkvef1",
-        "card": null
-      },
-      "occurrences": {
-        "object": "list",
-        "from": "1970-01-01T07:00:00+07:00",
-        "to": "2017-05-16T14:32:25+07:00",
-        "offset": 0,
-        "limit": 20,
-        "total": 0,
-        "order": null,
-        "location": "/schedules/schd_57zhl296uxc7yiun6xa/occurrences",
-        "data": [
-
-        ]
-      },
-      "next_occurrences": [
-        "2017-05-20",
-        "2017-06-05",
-        "2017-06-10",
-        "2017-06-26",
-        "2017-07-01",
-        "2017-07-17",
-        "2017-07-22",
-        "2017-08-07",
-        "2017-08-12",
-        "2017-08-28",
-        "2017-09-02",
-        "2017-09-18",
-        "2017-09-23",
-        "2017-10-09",
-        "2017-10-14",
-        "2017-10-30",
-        "2017-11-04",
-        "2017-11-20",
-        "2017-11-25",
-        "2017-12-11",
-        "2017-12-16",
-        "2018-01-01",
-        "2018-01-06",
-        "2018-01-22",
-        "2018-01-27",
-        "2018-02-12",
-        "2018-02-17",
-        "2018-03-05",
-        "2018-03-10",
-        "2018-03-26"
-      ],
-      "created": "2017-05-16T07:23:11Z"
-    },
     {
       "object": "schedule",
       "id": "schd_57zhl296uxc7yiun6xx",


### PR DESCRIPTION
List of Endpoint related of Schedule API

- [x] get /charges/schedules
- [x] get /transfers/schedules
- [x] get /customers/:customer_id/schedules
- [x] get /recipients/:recipient_id/schedules
- [x] get /occurrences/:id
- [x] get /schedules/:id/occurrences