### PR TITLE
Support BankAccount JP

### DIFF
--- a/bank_account_jp.go
+++ b/bank_account_jp.go
@@ -1,0 +1,11 @@
+package omise
+
+// BankAccountJP represents Omise's bank account object for jp.
+type BankAccountJP struct {
+	Base
+	BankCode    string          `json:"bank_code" pretty:""`
+	BranchCode  string          `json:"branch_code" pretty:""`
+	AccountType BankAccountType `json:"account_type" pretty:""`
+	Number      string          `json:"number"`
+	Name        string          `json:"name" pretty:""`
+}

--- a/bank_account_type.go
+++ b/bank_account_type.go
@@ -1,0 +1,10 @@
+package omise
+
+// BankAccountType BankAccount an enumeration of possible types of BackAccount(s) which can be
+type BankAccountType string
+
+// BankAccountType can be one of the following list of constants:
+const (
+	Normal  BankAccountType = "normal"
+	Current BankAccountType = "current"
+)

--- a/internal/generator/main.go
+++ b/internal/generator/main.go
@@ -15,6 +15,7 @@ var Context = &struct {
 		"Account",
 		"Balance",
 		"BankAccount",
+		"BankAccountJP",
 		"Card",
 		"Charge",
 		"Customer",

--- a/list_types.go
+++ b/list_types.go
@@ -62,6 +62,25 @@ func (list *BankAccountList) Find(id string) *BankAccount {
 	return nil
 }
 
+// BankAccountJPList represents the list structure returned by Omise's REST API that contains
+// BankAccountJP struct as member elements. See the pagination and lists documentation at
+// https://www.omise.co/api-pagination for more information.
+type BankAccountJPList struct {
+	List
+	Data []*BankAccountJP `json:"data"`
+}
+
+// Find finds and returns BankAccountJP with the given id. Returns nil if not found.
+func (list *BankAccountJPList) Find(id string) *BankAccountJP {
+	for _, item := range list.Data {
+		if item.ID == id {
+			return item
+		}
+	}
+
+	return nil
+}
+
 // CardList represents the list structure returned by Omise's REST API that contains
 // Card struct as member elements. See the pagination and lists documentation at
 // https://www.omise.co/api-pagination for more information.

--- a/operations/recipient.go
+++ b/operations/recipient.go
@@ -70,6 +70,46 @@ func (req *CreateRecipient) Op() *internal.Op {
 
 // Example:
 //
+//	bankAccount := &omise.BankAccountJP{
+//		BankCode:    "0001",
+//		BranchCode:  "001",
+//  	AccountType: omise.Normal,
+//  	Number:      "0000001",
+//		Name:        "Joe Example",
+//	}
+//
+//	jun, create := &omise.Recipient{}, &CreateRecipientJP{
+//		Name:        "Jun Hasegawa",
+//		Email:       "jun@omise.co",
+//		Description: "Owns Omise",
+//		Type:        omise.Individual,
+//		BankAccount: bankAccount,
+//	}
+//	if e := client.Do(jun, create); e != nil {
+//		panic(e)
+//	}
+//
+//	fmt.Println("created recipient:", jun.ID)
+//
+type CreateRecipientJP struct {
+	Name        string
+	Email       string
+	Description string
+	Type        omise.RecipientType
+	TaxID       string               `query:"tax_id"`
+	BankAccount *omise.BankAccountJP `query:"bank_account"`
+}
+
+func (req *CreateRecipientJP) Op() *internal.Op {
+	return &internal.Op{
+		Endpoint: internal.API,
+		Method:   "POST",
+		Path:     "/recipients",
+	}
+}
+
+// Example:
+//
 //	recp, retrieve := &omise.Recipient{}, &RetrieveRecipient{"recp_123"}
 //	if e := client.Do(recp, retrieve); e != nil {
 //		panic(e)


### PR DESCRIPTION
Since Omise Japan needed to specify bank_code instead of brand, we added BankAccountJP separately from BankAccount.