### PR TITLE
Supports change of default card with customer update

### DIFF
--- a/operations/customer.go
+++ b/operations/customer.go
@@ -97,6 +97,7 @@ type UpdateCustomer struct {
 	Email       string
 	Description string
 	Card        string
+	DefaultCard string `json:"default_card"`
 }
 
 func (req *UpdateCustomer) Op() *internal.Op {


### PR DESCRIPTION
I asked for support, but when changing such a default card, I heard that I should use this field, so I added it!