### PR TITLE
Change Refund.Metadata type to map

### DIFF
--- a/refund.go
+++ b/refund.go
@@ -4,9 +4,9 @@ package omise
 // See https://www.omise.co/refunds-api for more information.
 type Refund struct {
 	Base
-	Amount      int64  `json:"amount"`
-	Currency    string `json:"currency"`
-	Charge      string `json:"charge"`
-	Transaction string `json:"transaction"`
-	Metadata    string `json:"metadata"`
+	Amount      int64                  `json:"amount"`
+	Currency    string                 `json:"currency"`
+	Charge      string                 `json:"charge"`
+	Transaction string                 `json:"transaction"`
+	Metadata    map[string]interface{} `json:"metadata"`
 }


### PR DESCRIPTION
Change type of `Refund.Metadata` from `string` to `map[string]interface{}`