### PR TITLE
Fix wrong list charge and customer because forgot content type.

### DIFF
--- a/operations/charge.go
+++ b/operations/charge.go
@@ -27,9 +27,10 @@ type ListCharges struct {
 
 func (req *ListCharges) Describe() *internal.Description {
 	return &internal.Description{
-		Endpoint: internal.API,
-		Method:   "GET",
-		Path:     "/charges",
+		Endpoint:    internal.API,
+		Method:      "GET",
+		Path:        "/charges",
+		ContentType: "application/json",
 	}
 }
 

--- a/operations/customer.go
+++ b/operations/customer.go
@@ -24,9 +24,10 @@ type ListCustomers struct {
 
 func (req *ListCustomers) Describe() *internal.Description {
 	return &internal.Description{
-		Endpoint: internal.API,
-		Method:   "GET",
-		Path:     "/customers",
+		Endpoint:    internal.API,
+		Method:      "GET",
+		Path:        "/customers",
+		ContentType: "application/json",
 	}
 }
 


### PR DESCRIPTION
- ListCharges and ListCustomers operation cannot working correctly because forgot content type.