### PR TITLE
Deprecates build with 1.8.x

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,8 @@ script:
   - gometalinter --install
   - ./build.sh
 go:
-- 1.8.x
 - 1.9.x
+- 1.10.x
+- 1.11.x
+- 1.12.x
 - tip


### PR DESCRIPTION
Because gometalinter tool support for version >= 1.9.x.