### PR TITLE
Empty event panic fix

### DIFF
--- a/event.go
+++ b/event.go
@@ -32,10 +32,12 @@ func (ev *Event) UnmarshalJSON(buffer []byte) error {
 	proxy.Key = shim.Key
 
 	// Pre-init the right structure to match the returned type.
-	if shim.Data.Deleted {
-		proxy.Data = shim.Data // already *Deletion
-	} else {
-		proxy.Data = ev.dataInstanceFromType(shim.Data.Object)
+	if shim.Data != nil {
+		if shim.Data.Deleted {
+			proxy.Data = shim.Data // already *Deletion
+		} else {
+			proxy.Data = ev.dataInstanceFromType(shim.Data.Object)
+		}
 	}
 
 	if err := json.Unmarshal(buffer, &proxy); err != nil {

--- a/event_test.go
+++ b/event_test.go
@@ -1,0 +1,38 @@
+package omise_test
+
+import (
+	"testing"
+
+	. "github.com/omise/omise-go"
+	r "github.com/stretchr/testify/require"
+)
+
+func TestEvent_UnmarshalJSON(t *testing.T) {
+	type args struct {
+		buffer []byte
+	}
+	tests := []struct {
+		name string
+		args args
+	}{
+		{
+			name: "should unmarshal event",
+			args: args{
+				buffer: []byte(`{"key":"charge.complete", "data":{"object":"charge", "deleted":true}}`),
+			},
+		},
+		{
+			name: "should unmarshal empty event",
+			args: args{
+				buffer: []byte(`{}`),
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ev := &Event{}
+			err := ev.UnmarshalJSON(tt.args.buffer)
+			r.NoError(t, err)
+		})
+	}
+}


### PR DESCRIPTION
When I try to unmarshal the payload without `data` field. It always panic and break the code

**Payload:**
```json
{
    "key": "charge.complete"
}
```

**Panic message:**
```
panic: runtime error: invalid memory address or nil pointer dereference [recovered]
        panic: runtime error: invalid memory address or nil pointer dereference
```

**Changes:**
- Check `shim.Data` before using it
- Add `event_test.go` to test `UnmarshalJSON`