### PR TITLE
Support extra user agent

### DIFF
--- a/client.go
+++ b/client.go
@@ -32,6 +32,7 @@ type Client struct {
 	GoVersion     string
 	customHeaders map[string]string
 	ctx           context.Context
+	userAgent     string
 }
 
 // NewClient creates and returns a Client with the given public key and secret key.  Signs
@@ -77,6 +78,11 @@ func (c *Client) WithContext(ctx context.Context) {
 	}
 }
 
+// WithUserAgent feature allows us to append additional userAgent information to the original user agent.
+func (c *Client) WithUserAgent(userAgent string) {
+	c.userAgent = userAgent
+}
+
 // Request creates a new *http.Request that should performs the supplied Operation. Most
 // people should use the Do method instead.
 func (c *Client) Request(operation internal.Operation) (req *http.Request, err error) {
@@ -116,7 +122,8 @@ func (c *Client) buildJSONRequest(operation internal.Operation) (*http.Request, 
 }
 
 func (c *Client) setRequestHeaders(req *http.Request, desc *internal.Description) error {
-	ua := "OmiseGo/" + libraryVersion
+	ua := c.userAgent
+	ua += " OmiseGo/" + libraryVersion
 	if c.GoVersion != "" {
 		ua += " Go/" + c.GoVersion
 	}
@@ -125,7 +132,7 @@ func (c *Client) setRequestHeaders(req *http.Request, desc *internal.Description
 		req.Header.Add("Content-Type", desc.ContentType)
 	}
 
-	req.Header.Add("User-Agent", ua)
+	req.Header.Add("User-Agent", strings.TrimSpace(ua))
 	if c.APIVersion != "" {
 		req.Header.Add("Omise-Version", c.APIVersion)
 	}

--- a/client_test.go
+++ b/client_test.go
@@ -85,7 +85,6 @@ func TestClient_Request(t *testing.T) {
 	r.NoError(t, err)
 	r.Contains(t, req.Header.Get("User-Agent"), "OmiseGo/")
 	r.Contains(t, req.Header.Get("User-Agent"), "Go/go")
-	r.Contains(t, req.Header.Get("User-Agent"), "Go/go")
 	r.Contains(t, req.Header.Get("X-Header-ABC"), "ABC")
 	r.Empty(t, req.Header.Get("Omise-Version"), "Omise-Version header sent when APIVersion is not specified.")
 

--- a/client_test.go
+++ b/client_test.go
@@ -85,6 +85,7 @@ func TestClient_Request(t *testing.T) {
 	r.NoError(t, err)
 	r.Contains(t, req.Header.Get("User-Agent"), "OmiseGo/")
 	r.Contains(t, req.Header.Get("User-Agent"), "Go/go")
+	r.Contains(t, req.Header.Get("User-Agent"), "Go/go")
 	r.Contains(t, req.Header.Get("X-Header-ABC"), "ABC")
 	r.Empty(t, req.Header.Get("Omise-Version"), "Omise-Version header sent when APIVersion is not specified.")
 
@@ -94,6 +95,11 @@ func TestClient_Request(t *testing.T) {
 	r.NoError(t, err)
 	r.Contains(t, req.Header.Get("User-Agent"), "Go/RANDOMXXXVERSION")
 	r.Equal(t, req.Header.Get("Omise-Version"), "yadda")
+
+	client.WithUserAgent("OmiseShopify/2.0.0 CheckoutPage/1.0.0")
+	req, err = client.Request(desc)
+	r.NoError(t, err)
+	r.Contains(t, req.Header.Get("User-Agent"), "OmiseShopify/2.0.0 CheckoutPage/1.0.0")
 }
 
 func TestClient_Error(t *testing.T) {


### PR DESCRIPTION
# Support extra user agent

```go
result := &omise.Account{}

// pass extra user agent
client.WithUserAgent("OmiseShopify/2.0.0 CheckoutPage/1.0.0") 

err := client.Do(result, &operations.RetrieveAccount{})
```

Above code will become user agent as `OmiseShopify/2.0.0 CheckoutPage/1.0.0 OmiseGo/1.0.12 Go/go1.21`