### PR TITLE
Bump v1.1.0

### DIFF
--- a/client.go
+++ b/client.go
@@ -14,7 +14,7 @@ import (
 )
 
 // Library version to include in user agent
-var libraryVersion = "1.0.12"
+var libraryVersion = "1.1.0"
 
 // Client helps you configure and perform HTTP operations against Omise's REST API. It
 // should be used with operation structures from the operations subpackage.


### PR DESCRIPTION
**Note:** Switching to [semantic](https://semver.org/) versioning conventions from this release onwards.