### PR TITLE
Enable debug option

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ If you are using an older version of Go, please consider upgrading to a compatib
 
 ## Usage
 
-See [godoc.org][0] in tandem with the [Opn Payments API Documentation][1] for usage instructions.
+For usage instructions, see [godoc.org][0] in tandem with the [Opn Payments API Documentation][1].
 
 Example:
 
@@ -87,12 +87,12 @@ func main() {
 ## API version
 
 You can choose the API version to use with Opn Payments. Each new API version has new features
-and might not be compatible with previous versions. You can change the default version by
+that might be incompatible with previous versions. You can change the default version by
 visiting your Opn Payments Dashboard.
 
 The version configured here will have higher priority than the version set in your Opn Payments
 account. This is useful if you have multiple environments with different API versions for
-testing. (e.g. Development on the latest version but production is on an older version).
+testing. (e.g., Development on the latest version, but production is on an older version).
 
 ```
 client.APIVersion = "2015-11-06"
@@ -103,7 +103,7 @@ learn more about this feature in our [versioning guide](https://docs.opn.ooo/api
 
 ## Enable debug mode
 
-You can monitor the response code and body from each API call by utilizing the debug mode provided by the library which can be turned on or off. You can activate this feature by invoking `SetDebug()` immediately after initializing your client.
+You can monitor the response code and body from each API call by utilizing the library's debug mode, which you can turn on or off. To activate this feature, invoke `SetDebug()` immediately after initializing your client.
 
 ```
 client, e := omise.NewClient(OmisePublicKey, OmiseSecretKey)

--- a/README.md
+++ b/README.md
@@ -101,6 +101,20 @@ client.APIVersion = "2015-11-06"
 It is highly recommended to set this version to the current version that you are using. You can
 learn more about this feature in our [versioning guide](https://docs.opn.ooo/api-versioning).
 
+## Enable debug mode
+
+You can monitor the response code and body from each API call by utilizing the debug mode provided by the library which can be turned on or off. You can activate this feature by invoking `SetDebug()` immediately after initializing your client.
+
+```
+client, e := omise.NewClient(OmisePublicKey, OmiseSecretKey)
+if e != nil {
+	log.Fatal(e)
+}
+
+// Enabling debug mode to monitor response from API call
+client.SetDebug(true)
+```
+
 ## License
 
 See [LICENSE][2] file.

--- a/client.go
+++ b/client.go
@@ -83,6 +83,11 @@ func (c *Client) WithUserAgent(userAgent string) {
 	c.userAgent = userAgent
 }
 
+// If set to true then library will print the response of all the endpoints.
+func (c *Client) SetDebug(debug bool) {
+	c.debug = debug
+}
+
 // Request creates a new *http.Request that should performs the supplied Operation. Most
 // people should use the Do method instead.
 func (c *Client) Request(operation internal.Operation) (req *http.Request, err error) {

--- a/client_test.go
+++ b/client_test.go
@@ -141,6 +141,14 @@ func TestClient_WithContext(t *testing.T) {
 	r.Equal(t, account.ID, "acct_4yq6tcsyoged5c0ocxd")
 }
 
+func TestClient_SetDebug(t *testing.T) {
+	client := testutil.NewFixedClient(t)
+	client.SetDebug(true)
+	account := &Account{}
+	client.MustDo(account, &operations.RetrieveAccount{})
+	r.Equal(t, account.ID, "acct_4yq6tcsyoged5c0ocxd")
+}
+
 func ExampleClient_Do() {
 	// gets your API keys
 	pkey, skey := "pkey_test_4yq6tct0llin5nyyi5l", "skey_test_4yq6tct0lblmed2yp5t"


### PR DESCRIPTION
## Description

Provide an API to enable/disable debug mode.

- Added a method `SetDebug()` to enable/disable debug mode in client.go
```
client, e := omise.NewClient(OmisePublicKey, OmiseSecretKey)
if e != nil {
	log.Fatal(e)
}

// Enabling debug mode to monitor response from API call
client.SetDebug(true)
```
- Updated README.md to include information about debug mode.

## Rollback procedure

`default rollback procedure`
