### PR TITLE
[MC TAS PASSKEY] support authentication type in charge API

### DIFF
--- a/authentication_type.go
+++ b/authentication_type.go
@@ -1,0 +1,8 @@
+package omise
+
+type AuthenticationType string
+
+const (
+	ThreeDS AuthenticationType = "3DS"
+	Passkey AuthenticationType = "PASSKEY"
+)

--- a/authentication_type_test.go
+++ b/authentication_type_test.go
@@ -1,0 +1,94 @@
+package omise_test
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/omise/omise-go"
+	r "github.com/stretchr/testify/require"
+)
+
+func TestAuthenticationType_Constants(t *testing.T) {
+	// Test that constants are defined correctly
+	r.Equal(t, omise.AuthenticationType("3DS"), omise.ThreeDS)
+	r.Equal(t, omise.AuthenticationType("PASSKEY"), omise.Passkey)
+}
+
+func TestAuthenticationType_JSONMarshal(t *testing.T) {
+	testCases := []struct {
+		name     string
+		authType omise.AuthenticationType
+		expected string
+	}{
+		{
+			name:     "ThreeDS",
+			authType: omise.ThreeDS,
+			expected: `"3DS"`,
+		},
+		{
+			name:     "Passkey",
+			authType: omise.Passkey,
+			expected: `"PASSKEY"`,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			b, err := json.Marshal(tc.authType)
+			r.NoError(t, err)
+			r.Equal(t, tc.expected, string(b))
+		})
+	}
+}
+
+func TestAuthenticationType_JSONUnmarshal(t *testing.T) {
+	testCases := []struct {
+		name     string
+		json     string
+		expected omise.AuthenticationType
+	}{
+		{
+			name:     "ThreeDS",
+			json:     `"3DS"`,
+			expected: omise.ThreeDS,
+		},
+		{
+			name:     "Passkey",
+			json:     `"PASSKEY"`,
+			expected: omise.Passkey,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			var authType omise.AuthenticationType
+			err := json.Unmarshal([]byte(tc.json), &authType)
+			r.NoError(t, err)
+			r.Equal(t, tc.expected, authType)
+		})
+	}
+}
+
+func TestAuthenticationType_Pointer(t *testing.T) {
+	// Test pointer handling for nullable field
+	authType := omise.ThreeDS
+	ptr := &authType
+
+	// Test marshaling pointer
+	b, err := json.Marshal(ptr)
+	r.NoError(t, err)
+	r.Equal(t, `"3DS"`, string(b))
+
+	// Test unmarshaling to pointer
+	var unmarshaledPtr *omise.AuthenticationType
+	err = json.Unmarshal(b, &unmarshaledPtr)
+	r.NoError(t, err)
+	r.NotNil(t, unmarshaledPtr)
+	r.Equal(t, omise.ThreeDS, *unmarshaledPtr)
+
+	// Test null pointer
+	var nullPtr *omise.AuthenticationType
+	b, err = json.Marshal(nullPtr)
+	r.NoError(t, err)
+	r.Equal(t, "null", string(b))
+}

--- a/authentication_type_test.go
+++ b/authentication_type_test.go
@@ -8,13 +8,12 @@ import (
 	r "github.com/stretchr/testify/require"
 )
 
-func TestAuthenticationType_Constants(t *testing.T) {
-	// Test that constants are defined correctly
+func TestAuthenticationTypeConstants(t *testing.T) {
 	r.Equal(t, omise.AuthenticationType("3DS"), omise.ThreeDS)
 	r.Equal(t, omise.AuthenticationType("PASSKEY"), omise.Passkey)
 }
 
-func TestAuthenticationType_JSONMarshal(t *testing.T) {
+func TestAuthenticationTypeJSONMarshal(t *testing.T) {
 	testCases := []struct {
 		name     string
 		authType omise.AuthenticationType
@@ -41,7 +40,7 @@ func TestAuthenticationType_JSONMarshal(t *testing.T) {
 	}
 }
 
-func TestAuthenticationType_JSONUnmarshal(t *testing.T) {
+func TestAuthenticationTypeJSONUnmarshal(t *testing.T) {
 	testCases := []struct {
 		name     string
 		json     string
@@ -69,7 +68,7 @@ func TestAuthenticationType_JSONUnmarshal(t *testing.T) {
 	}
 }
 
-func TestAuthenticationType_Pointer(t *testing.T) {
+func TestAuthenticationTypePointer(t *testing.T) {
 	// Test pointer handling for nullable field
 	authType := omise.ThreeDS
 	ptr := &authType

--- a/authorization_types.go
+++ b/authorization_types.go
@@ -5,6 +5,6 @@ type AuthorizationType string
 
 // AuthorizationType can be one of the following list of constants:
 const (
-	PreAuth     AuthorizationType = "pre_auth"
-	FinalAuth    AuthorizationType = "final_auth"
+	PreAuth   AuthorizationType = "pre_auth"
+	FinalAuth AuthorizationType = "final_auth"
 )

--- a/charge.go
+++ b/charge.go
@@ -40,9 +40,10 @@ type Charge struct {
 	Metadata  map[string]interface{} `json:"metadata"`
 	ExpiresAt time.Time              `json:"expires_at"`
 
-	MerchantAdvice     string   `json:"merchant_advice"`
-	MerchantAdviceCode string   `json:"merchant_advice_code"`
-	Missing3DSFields   []string `json:"missing_3ds_fields"`
+	MerchantAdvice     string              `json:"merchant_advice"`
+	MerchantAdviceCode string              `json:"merchant_advice_code"`
+	Missing3DSFields   []string            `json:"missing_3ds_fields"`
+	AuthenticatedBy    *AuthenticationType `json:"authenticated_by"`
 }
 
 type TransactionIndicator string

--- a/operations/charge.go
+++ b/operations/charge.go
@@ -70,6 +70,7 @@ type CreateCharge struct {
 	LinkedAccount            string                     `json:"linked_account,omitempty"`
 	FirstCharge              string                     `json:"first_charge,omitempty"`
 	PlatformFee              omise.PlatformFee          `json:"platform_fee,omitempty"`
+	Authentication           omise.AuthenticationType   `json:"authentication,omitempty"`
 }
 
 func (req *CreateCharge) MarshalJSON() ([]byte, error) {

--- a/operations/charge_test.go
+++ b/operations/charge_test.go
@@ -353,7 +353,7 @@ func TestRetrieveChargeHas3DSFields(t *testing.T) {
 	r.Equal(t, []string{"phone_number", "address"}, charge.Missing3DSFields)
 }
 
-func TestCharge_Authentication_Network(t *testing.T) {
+func TestChargeAuthenticationNetwork(t *testing.T) {
 	testutil.Require(t, "network")
 	client := testutil.NewTestClient(t)
 
@@ -378,7 +378,7 @@ func TestCharge_Authentication_Network(t *testing.T) {
 	// Note: authenticated_by field verification depends on API response
 }
 
-func TestCreateCharge_ZeroAmountPasskey_Network(t *testing.T) {
+func TestCreateChargeZeroAmountPasskeyNetwork(t *testing.T) {
 	testutil.Require(t, "network")
 	client := testutil.NewTestClient(t)
 
@@ -404,7 +404,7 @@ func TestCreateCharge_ZeroAmountPasskey_Network(t *testing.T) {
 	r.Equal(t, int64(0), charge.Amount)
 }
 
-func TestCreateCharge_ZeroAmountValidation_Marshal(t *testing.T) {
+func TestCreateChargeZeroAmountValidationMarshal(t *testing.T) {
 	// Test JSON marshalling of zero-amount PASSKEY charge
 	req := &CreateCharge{
 		Amount:         0,

--- a/operations/charge_test.go
+++ b/operations/charge_test.go
@@ -76,6 +76,31 @@ func TestCreateChargeMarshal(t *testing.T) {
 			},
 			`{"amount":10000,"currency":"thb","description":"This is a card cahrge","metadata":{"Hello":"World"},"webhook_endpoints":["https://docs.omise.co/api-webhooks"],"ip":"192.168.1.1","transaction_indicator":"MIT","platform_fee":{"fixed":10,"percentage":2}}`,
 		},
+		{
+			&CreateCharge{
+				Amount:         10000,
+				Currency:       "thb",
+				Authentication: omise.ThreeDS,
+			},
+			`{"amount":10000,"currency":"thb","platform_fee":{},"authentication":"3DS"}`,
+		},
+		{
+			&CreateCharge{
+				Amount:         10000,
+				Currency:       "thb",
+				Authentication: omise.Passkey,
+			},
+			`{"amount":10000,"currency":"thb","platform_fee":{},"authentication":"PASSKEY"}`,
+		},
+		{
+			&CreateCharge{
+				Amount:         0,
+				Currency:       "thb",
+				Card:           "tokn_test_xxx",
+				Authentication: omise.Passkey,
+			},
+			`{"card":"tokn_test_xxx","amount":0,"currency":"thb","platform_fee":{},"authentication":"PASSKEY"}`,
+		},
 	}
 	for _, td := range testdata {
 		b, err := json.Marshal(td.req)
@@ -326,4 +351,71 @@ func TestRetrieveChargeHas3DSFields(t *testing.T) {
 	r.Equal(t, "additional authentication required", charge.MerchantAdvice)
 	r.Equal(t, "03", charge.MerchantAdviceCode)
 	r.Equal(t, []string{"phone_number", "address"}, charge.Missing3DSFields)
+}
+
+func TestCharge_Authentication_Network(t *testing.T) {
+	testutil.Require(t, "network")
+	client := testutil.NewTestClient(t)
+
+	token := &omise.Token{}
+	client.MustDo(token, &CreateToken{
+		Name:            "John Doe",
+		Number:          "4242424242424242",
+		ExpirationMonth: 12,
+		ExpirationYear:  time.Now().AddDate(1, 0, 0).Year(),
+	})
+
+	// Test 3DS authentication
+	charge := &omise.Charge{}
+	client.MustDo(charge, &CreateCharge{
+		Amount:         50000,
+		Currency:       "thb",
+		Card:           token.ID,
+		Authentication: omise.ThreeDS,
+	})
+
+	r.NotEmpty(t, charge.ID)
+	// Note: authenticated_by field verification depends on API response
+}
+
+func TestCreateCharge_ZeroAmountPasskey_Network(t *testing.T) {
+	testutil.Require(t, "network")
+	client := testutil.NewTestClient(t)
+
+	token := &omise.Token{}
+	client.MustDo(token, &CreateToken{
+		Name:            "John Doe",
+		Number:          "4242424242424242",
+		ExpirationMonth: 12,
+		ExpirationYear:  time.Now().AddDate(1, 0, 0).Year(),
+	})
+
+	// Test zero-amount charge with PASSKEY authentication
+	charge := &omise.Charge{}
+	client.MustDo(charge, &CreateCharge{
+		Amount:         0, // Zero amount
+		Currency:       "thb",
+		Card:           token.ID,
+		Authentication: omise.Passkey,
+		// Customer: nil (required condition)
+	})
+
+	r.NotEmpty(t, charge.ID)
+	r.Equal(t, int64(0), charge.Amount)
+}
+
+func TestCreateCharge_ZeroAmountValidation_Marshal(t *testing.T) {
+	// Test JSON marshalling of zero-amount PASSKEY charge
+	req := &CreateCharge{
+		Amount:         0,
+		Currency:       "thb",
+		Card:           "tokn_test_xxx",
+		Authentication: omise.Passkey,
+	}
+
+	expected := `{"card":"tokn_test_xxx","amount":0,"currency":"thb","platform_fee":{},"authentication":"PASSKEY"}`
+
+	b, err := json.Marshal(req)
+	r.Nil(t, err)
+	r.Equal(t, expected, string(b))
 }

--- a/operations/token_test.go
+++ b/operations/token_test.go
@@ -64,7 +64,7 @@ func TestTokenWithEmailPhoneNetwork(t *testing.T) {
 	r.NotEmpty(t, token.ID)
 }
 
-func TestCreateToken_EmailPhone_Marshal(t *testing.T) {
+func TestCreateTokenEmailPhoneMarshal(t *testing.T) {
 	req := &CreateToken{
 		Name:            "John Doe",
 		Number:          "4242424242424242",

--- a/operations/token_test.go
+++ b/operations/token_test.go
@@ -10,6 +10,11 @@ import (
 	r "github.com/stretchr/testify/require"
 )
 
+const (
+	testEmail       = "john@example.com"
+	testPhoneNumber = "+66812345678"
+)
+
 func TestToken(t *testing.T) {
 	const TokenID = "tokn_test_4yq8lbecl0q6dsjzxr5"
 	client := testutil.NewFixedClient(t)
@@ -39,7 +44,7 @@ func TestToken_Network(t *testing.T) {
 	r.Equal(t, *tok1, *tok2)
 }
 
-func TestToken_WithEmailPhone_Network(t *testing.T) {
+func TestTokenWithEmailPhoneNetwork(t *testing.T) {
 	testutil.Require(t, "network")
 	client := testutil.NewTestClient(t)
 
@@ -50,8 +55,8 @@ func TestToken_WithEmailPhone_Network(t *testing.T) {
 		ExpirationMonth: 12,
 		ExpirationYear:  2025,
 		SecurityCode:    "123",
-		Email:           "john@example.com",
-		PhoneNumber:     "+66812345678",
+		Email:           testEmail,
+		PhoneNumber:     testPhoneNumber,
 		City:            "Bangkok",
 		PostalCode:      "10240",
 	})
@@ -66,8 +71,8 @@ func TestCreateToken_EmailPhone_Marshal(t *testing.T) {
 		ExpirationMonth: 12,
 		ExpirationYear:  2025,
 		SecurityCode:    "123",
-		Email:           "john@example.com",
-		PhoneNumber:     "+66812345678",
+		Email:           testEmail,
+		PhoneNumber:     testPhoneNumber,
 		City:            "Bangkok",
 		PostalCode:      "10240",
 	}
@@ -81,8 +86,8 @@ func TestCreateToken_EmailPhone_Marshal(t *testing.T) {
 
 	card, ok := result["card"].(map[string]interface{})
 	r.True(t, ok, "card field should exist")
-	r.Equal(t, "john@example.com", card["email"])
-	r.Equal(t, "+66812345678", card["phone_number"])
+	r.Equal(t, testEmail, card["email"])
+	r.Equal(t, testPhoneNumber, card["phone_number"])
 	r.Equal(t, "Bangkok", card["city"])
 	r.Equal(t, "10240", card["postal_code"])
 }


### PR DESCRIPTION
## Description
- support authentication type enum (3DS and PASSKEY) for charge creation
- this field is needed when doing PASSKEY authorization
